### PR TITLE
(E429-269) Allowing to bypass the `is_selected` validation

### DIFF
--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -85,8 +85,9 @@ def main():
     if args.discover:
         do_discover(args.config)
     elif args.properties:
-        if config["skip_stream_is_selected"]:
-            do_sync(config, args.properties, args.state, skip_stream_is_selected=config["skip_stream_is_selected"])
+        skip_stream_validation = config.get("skip_stream_is_selected", False)
+        if skip_stream_validation:
+            do_sync(config, args.properties, args.state, skip_stream_is_selected=skip_stream_validation)
         else:
             do_sync(config, args.properties, args.state)
 

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -27,16 +27,17 @@ def stream_is_selected(mdata):
     return mdata.get((), {}).get('selected', False)
 
 
-def do_sync(config, catalog, state):
+def do_sync(config, catalog, state, skip_stream_is_selected=False):
     LOGGER.info('Starting sync.')
 
     for stream in catalog['streams']:
         stream_name = stream['tap_stream_id']
         mdata = metadata.to_map(stream['metadata'])
         table_spec = next(s for s in config['tables'] if s['table_name'] == stream_name)
-        if not stream_is_selected(mdata):
-            LOGGER.info("%s: Skipping - not selected", stream_name)
-            continue
+        if not skip_stream_is_selected:
+            if not stream_is_selected(mdata):
+                LOGGER.info("%s: Skipping - not selected", stream_name)
+                continue
 
         singer.write_state(state)
         key_properties = metadata.get(mdata, (), 'table-key-properties')
@@ -84,7 +85,10 @@ def main():
     if args.discover:
         do_discover(args.config)
     elif args.properties:
-        do_sync(config, args.properties, args.state)
+        if config["skip_stream_is_selected"]:
+            do_sync(config, args.properties, args.state, skip_stream_is_selected=config["skip_stream_is_selected"])
+        else:
+            do_sync(config, args.properties, args.state)
 
 
 if __name__ == '__main__':

--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -85,7 +85,7 @@ def main():
     if args.discover:
         do_discover(args.config)
     elif args.properties:
-        skip_stream_validation = config.get("skip_stream_is_selected", False)
+        skip_stream_validation = str(config.get("skip_stream_is_selected")).lower() == "true"
         if skip_stream_validation:
             do_sync(config, args.properties, args.state, skip_stream_is_selected=skip_stream_validation)
         else:


### PR DESCRIPTION
# what
- Including the functionality to skip the `is_selected` validation.


# why
- For https://github.com/cherreco/data/pull/3798, we are able to continue using the `--config` flag in our tap while it encapsulates the `--discover` and `--properties` process. 


# notes
- https://cherre.atlassian.net/jira/software/projects/E429/boards/61?selectedIssue=E429-269

# screenshot
![image](https://user-images.githubusercontent.com/20485316/80976137-0e9c9900-8df1-11ea-8262-861f94b82a8e.png)


# checklist
- [x] Provide evidence of manual testing (e.g. screenshots)
- [x] Another person has manually tested/verified my work (e.g. ran DAGs)
- [x] Cross-reference the JIRA story in the PR title using the `(PRJ-NNNN) PR Title` format
- [x] Remove boiler plate text from the PR description, if unused.
