### PR TITLE
Pass Assume Role Error as Info

### DIFF
--- a/tap_s3_csv/__init__.py
+++ b/tap_s3_csv/__init__.py
@@ -78,7 +78,7 @@ def main():
     try:
         for page in s3.list_files_in_bucket(config['bucket']):
             break
-        LOGGER.warning("I have direct access to the bucket without assuming the configured role.")
+        LOGGER.info("I have direct access to the bucket without assuming the configured role.")
     except:
         s3.setup_aws_client(config)
 


### PR DESCRIPTION
# what

Updates warning for assuming role from log level `warning` to `info`

# why

Failing in Airflow, while we do not need to assume a role